### PR TITLE
Don't require Actor to be Send

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -4,7 +4,7 @@ use crate :: { import::*, Return };
 /// An actor is an isolated computing unit. For an introduction to the actor model, see:
 /// - https://youtu.be/7erJ1DV_Tlo
 //
-pub trait Actor: 'static + Send
+pub trait Actor: 'static
 {
 	/// Gets called just before the mailbox starts listening for incoming messages.
 	/// You can do this to do setup for your actor.

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -11,5 +11,12 @@ pub trait Envelope<A> where A: Actor, Self: Send
 	//
 	#[ must_use = "Futures do nothing unless polled" ]
 	//
-	fn handle( self: Box<Self>, actor: &mut A ) -> Return<()>;
+	fn handle( self: Box<Self>, actor: &mut A ) -> Return<()> where A: Send;
+
+
+	/// Have the actor handle the message, for !Send Actors.
+	//
+	#[ must_use = "Futures do nothing unless polled" ]
+	//
+	fn handle_local( self: Box<Self>, actor: &mut A ) -> ReturnNoSend<()>;
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,7 +2,25 @@ use crate :: { * };
 
 pub trait Handler< M: Message > where Self: Actor
 {
+	/// Define how your actor handles this message type. If your actor is !Send,
+	/// you should implement `handle_local` and give `handle` an "unreachable!()" implementation.
+	/// It shall never be called.
+	//
 	#[ must_use = "Futures do nothing unless polled" ]
 	//
 	fn handle( &mut self, msg: M ) -> Return< <M as Message>::Return >;
+
+
+
+	/// Define how your actor handles this message type.
+	///
+	/// You still have to implement `handle` because that is a required method, but if your actor is Send
+	/// and you implement `handle`, you get `handle_local` automatically.
+	//
+	#[ must_use = "Futures do nothing unless polled" ]
+	//
+	fn handle_local( &mut self, msg: M ) -> ReturnNoSend< <M as Message>::Return >
+	{
+		self.handle( msg )
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ mod import
 		},
 
 		futures :: { prelude::{ Stream, Sink }, future::FutureExt, channel::{ oneshot, mpsc }, task::Spawn } ,
-		failure   :: { Fail, bail, err_msg, AsFail, Context as FailContext, Backtrace, ResultExt } ,
+		failure :: { Fail, bail, err_msg, AsFail, Context as FailContext, Backtrace, ResultExt } ,
 	};
 }
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -3,7 +3,7 @@ use crate :: { * };
 /// TODO: Right now this exposes the existance of a default runtime, which is not defined by iface... So
 /// this leaks implementation details.
 //
-pub trait Mailbox< A: Actor >
+pub trait Mailbox< A: Actor + Send >
 {
 	/// Start the mailbox. This consumes the mailbox for now, so get your addresses before running this.
 	/// You should spawn the future on a default executor.
@@ -16,4 +16,14 @@ pub trait Mailbox< A: Actor >
 	#[ must_use = "Futures do nothing unless polled" ]
 	//
 	fn start_fut( self, actor: A ) -> Return<'static, ()>;
+}
+
+
+pub trait MailboxFuture< A: Actor >
+{
+	/// Return a non-Send future that allows starting the mailbox.
+	///
+	#[ must_use = "Futures do nothing unless polled" ]
+	//
+	fn start_fut_local( self, actor: A ) -> ReturnNoSend<'static, ()>;
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -5,13 +5,11 @@ use crate :: { * };
 //
 pub trait Mailbox< A: Actor + Send >
 {
-	/// Start the mailbox. This consumes the mailbox for now, so get your addresses before running this.
-	/// You should spawn the future on a default executor.
-	///
+	/// Start the mailbox. This consumes the mailbox, so get your addresses before running this.
 	//
 	fn start( self, actor: A ) -> ThesRes<()>;
 
-	/// Return a future that allows starting the mailbox.
+	/// Return a future that allows starting the mailbox by spawning it on the executor of your choice.
 	///
 	#[ must_use = "Futures do nothing unless polled" ]
 	//
@@ -19,9 +17,15 @@ pub trait Mailbox< A: Actor + Send >
 }
 
 
-pub trait MailboxFuture< A: Actor >
+pub trait MailboxLocal< A: Actor >
 {
-	/// Return a non-Send future that allows starting the mailbox.
+	/// Start the mailbox. This consumes the mailbox, so get your addresses before running this.
+	//
+	#[ must_use = "Futures do nothing unless polled" ]
+	//
+	fn start_local( self, actor: A ) -> ThesRes<()>;
+
+	/// Return a non-Send future that allows starting the mailbox by spawning it on the executor of your choice.
 	///
 	#[ must_use = "Futures do nothing unless polled" ]
 	//


### PR DESCRIPTION
What do you think about dropping the `Send` requirement for `Actor`?

I guess the reason it's there is so it's easier to spawn an actor on a threaded future executor. But on the other hand it prevents one from spawning an actor on a _local_ executor.

To allow to spawn such a _local_ future also `Mailbox` should be changed. How about providing a way to get the `Future` for a mailbox (which can then be run on any executor), instead or besides providing a default `start()` that runs the future on a default executor?

I have no expectation for this PR to be merged, just wanted to get the conversation started and know if this is something you would consider or not.